### PR TITLE
Update runtime to org.freedesktop.Platform 19.08

### DIFF
--- a/io.thp.numptyphysics.json
+++ b/io.thp.numptyphysics.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.thp.numptyphysics",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "18.08",
+    "runtime-version": "19.08",
     "sdk": "org.freedesktop.Sdk",
     "finish-args": [
         "--device=dri",


### PR DESCRIPTION
Looks like this works nicely with 19.08, giving us a newer version of Mesa which will improve hardware support - particularly for Intel Ice Lake.