### PR TITLE
Update to Numpty Physics 0.3.9 and runtime 21.08

### DIFF
--- a/io.thp.numptyphysics.appdata.xml
+++ b/io.thp.numptyphysics.appdata.xml
@@ -20,6 +20,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release date="2021-06-18" version="0.3.8"/>
     <release date="2016-10-27" version="0.3.4"/>
   </releases>
   <updatecontact>m@thp.io</updatecontact>

--- a/io.thp.numptyphysics.appdata.xml
+++ b/io.thp.numptyphysics.appdata.xml
@@ -18,7 +18,7 @@
     <screenshot type="default">https://raw.githubusercontent.com/flathub/io.thp.numptyphysics/master/screenshots/1.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/flathub/io.thp.numptyphysics/master/screenshots/2.png</screenshot>
   </screenshots>
-  <content_rating type="oars-1.1" />
+  <content_rating type="oars-1.1"/>
   <releases>
     <release date="2021-06-18" version="0.3.8"/>
     <release date="2016-10-27" version="0.3.4"/>

--- a/io.thp.numptyphysics.appdata.xml
+++ b/io.thp.numptyphysics.appdata.xml
@@ -20,6 +20,7 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="0.3.9" date="2021-10-12"/>
     <release date="2021-06-18" version="0.3.8"/>
     <release date="2016-10-27" version="0.3.4"/>
   </releases>

--- a/io.thp.numptyphysics.json
+++ b/io.thp.numptyphysics.json
@@ -15,7 +15,8 @@
         "/share/aclocal",
         "/share/gtk-doc",
         "/share/man",
-        "*.la", "*.a"
+        "*.la",
+        "*.a"
     ],
     "rename-desktop-file": "numptyphysics.desktop",
     "rename-icon": "numptyphysics",

--- a/io.thp.numptyphysics.json
+++ b/io.thp.numptyphysics.json
@@ -29,8 +29,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/thp/numptyphysics/archive/0.3.4.tar.gz",
-                    "sha256": "e00e1535c8246f3f1c3bab37d2e6f01259a14f59b38382299457b4b8447d2bc9"
+                    "url": "https://github.com/thp/numptyphysics/archive/0.3.8.tar.gz",
+                    "sha256": "e5581dffbbbac37c0600deb2a1dd53491dd458937d40ac3f1243b4a4ef1d69fb"
                 },
                 {
                     "type": "file",

--- a/io.thp.numptyphysics.json
+++ b/io.thp.numptyphysics.json
@@ -30,7 +30,13 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/thp/numptyphysics/archive/0.3.8.tar.gz",
-                    "sha256": "e5581dffbbbac37c0600deb2a1dd53491dd458937d40ac3f1243b4a4ef1d69fb"
+                    "sha256": "e5581dffbbbac37c0600deb2a1dd53491dd458937d40ac3f1243b4a4ef1d69fb",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/thp/numptyphysics/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": "\"https://github.com/thp/numptyphysics/archive/\\(.tag_name).tar.gz\""
+                    }
                 },
                 {
                     "type": "file",

--- a/io.thp.numptyphysics.json
+++ b/io.thp.numptyphysics.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.thp.numptyphysics",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "19.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "finish-args": [
         "--device=dri",

--- a/io.thp.numptyphysics.json
+++ b/io.thp.numptyphysics.json
@@ -30,8 +30,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/thp/numptyphysics/archive/0.3.8.tar.gz",
-                    "sha256": "e5581dffbbbac37c0600deb2a1dd53491dd458937d40ac3f1243b4a4ef1d69fb",
+                    "url": "https://github.com/thp/numptyphysics/archive/0.3.9.tar.gz",
+                    "sha256": "aa836d1a113b0891096ea63ecc1aefd6070c35eb5c378ad9003b849898926618",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/thp/numptyphysics/releases/latest",


### PR DESCRIPTION
~~I had a quick look at https://github.com/flathub/flatpak-external-data-checker/ integration but couldn't quite put the pieces of the JQ checker together in the few minutes I had.~~

Also adds fedc integration.